### PR TITLE
Ensure dividers start after current emote

### DIFF
--- a/BookHorseBot/Program.cs
+++ b/BookHorseBot/Program.cs
@@ -116,7 +116,7 @@ namespace BookHorseBot
                                 "\r\n\r\n" +
                                 $"**Tags**: {GenerateTags(root)}";
                 }
-                template += "\r\n \r\n" +
+                template += " [](//sp) \r\n \r\n" +
                             "-----";
             }
             if (rootList.All(x => x.data.Length == 0) || rootList.Count == 0)


### PR DESCRIPTION
`[](/sp)` ensures the text starts after any current emote. This prevents multiple emotes from appearing on the same line.